### PR TITLE
chore: upgrade Infrahub to 1.9.6

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,11 +1,11 @@
 ---
 x-infrahub-custom-build: &infrahub_custom_build
-  image: opsmill/infrahub-demo-service-catalog:${INFRAHUB_BASE_VERSION:-1.8.2}
+  image: opsmill/infrahub-demo-service-catalog:${INFRAHUB_BASE_VERSION:-1.9.6}
   build:
     context: .
     dockerfile: Dockerfile
     args:
-      INFRAHUB_BASE_VERSION: "${INFRAHUB_BASE_VERSION:-1.8.2}"
+      INFRAHUB_BASE_VERSION: "${INFRAHUB_BASE_VERSION:-1.9.6}"
   environment:
     INFRAHUB_GIT_IMPORT_SYNC_BRANCH_NAMES: '["^demo/.*$"]'
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ x-infrahub-config: &infrahub_config
   INFRAHUB_API_CORS_ALLOW_ORIGINS:
   INFRAHUB_BROKER_ADDRESS: ${INFRAHUB_BROKER_ADDRESS:-localhost}
   INFRAHUB_BROKER_DRIVER: ${INFRAHUB_BROKER_DRIVER:-rabbitmq}
-  INFRAHUB_BROKER_ENABLE: ${INFRAHUB_BROKER_ENABLE:-true}
   INFRAHUB_BROKER_MAXIMUM_CONCURRENT_MESSAGES: ${INFRAHUB_BROKER_MAXIMUM_CONCURRENT_MESSAGES:-2}
   INFRAHUB_BROKER_MAXIMUM_MESSAGE_RETRIES: ${INFRAHUB_BROKER_MAXIMUM_MESSAGE_RETRIES:-10}
   INFRAHUB_BROKER_NAMESPACE: ${INFRAHUB_BROKER_NAMESPACE:-infrahub}
@@ -41,7 +40,6 @@ x-infrahub-config: &infrahub_config
   INFRAHUB_CACHE_CLEAN_UP_DEADLOCKS_INTERVAL_MINS: ${INFRAHUB_CACHE_CLEAN_UP_DEADLOCKS_INTERVAL_MINS:-15}
   INFRAHUB_CACHE_DATABASE: ${INFRAHUB_CACHE_DATABASE:-0}
   INFRAHUB_CACHE_DRIVER: ${INFRAHUB_CACHE_DRIVER:-redis}
-  INFRAHUB_CACHE_ENABLE: ${INFRAHUB_CACHE_ENABLE:-true}
   INFRAHUB_CACHE_PASSWORD: &cache_password ${INFRAHUB_CACHE_PASSWORD:-}
   INFRAHUB_CACHE_PORT:
   INFRAHUB_CACHE_TLS_CA_FILE:
@@ -59,16 +57,22 @@ x-infrahub-config: &infrahub_config
   INFRAHUB_DB_PORT: ${INFRAHUB_DB_PORT:-7687}
   INFRAHUB_DB_PROTOCOL: ${INFRAHUB_DB_PROTOCOL:-bolt}
   INFRAHUB_DB_QUERY_SIZE_LIMIT: ${INFRAHUB_DB_QUERY_SIZE_LIMIT:-5000}
+  INFRAHUB_DB_RETRY_BASE_DELAY: ${INFRAHUB_DB_RETRY_BASE_DELAY:-0.1}
+  INFRAHUB_DB_RETRY_JITTER_MAX: ${INFRAHUB_DB_RETRY_JITTER_MAX:-0.1}
   INFRAHUB_DB_RETRY_LIMIT: ${INFRAHUB_DB_RETRY_LIMIT:-3}
+  INFRAHUB_DB_RETRY_MAX_DELAY: ${INFRAHUB_DB_RETRY_MAX_DELAY:-2.0}
   INFRAHUB_DB_TLS_CA_FILE:
   INFRAHUB_DB_TLS_ENABLED: ${INFRAHUB_DB_TLS_ENABLED:-false}
   INFRAHUB_DB_TLS_INSECURE: ${INFRAHUB_DB_TLS_INSECURE:-false}
   INFRAHUB_DB_TYPE: ${INFRAHUB_DB_TYPE:-neo4j}
   INFRAHUB_DB_USERNAME: ${INFRAHUB_DB_USERNAME:-neo4j}
+  INFRAHUB_DELETE_BRANCH_AFTER_MERGE: ${INFRAHUB_DELETE_BRANCH_AFTER_MERGE:-false}
+  INFRAHUB_DIFF_UPDATE_AFTER_MERGE: ${INFRAHUB_DIFF_UPDATE_AFTER_MERGE:-true}
   INFRAHUB_DOCS_INDEX_PATH: ${INFRAHUB_DOCS_INDEX_PATH:-/opt/infrahub/docs/build/search-index.json}
   INFRAHUB_EXPERIMENTAL_GRAPHQL_ENUMS: ${INFRAHUB_EXPERIMENTAL_GRAPHQL_ENUMS:-false}
   INFRAHUB_EXPERIMENTAL_VALUE_DB_INDEX: ${INFRAHUB_EXPERIMENTAL_VALUE_DB_INDEX:-false}
   INFRAHUB_GIT_APPEND_GIT_SUFFIX:
+  INFRAHUB_GIT_DELETE_GIT_BRANCH_AFTER_MERGE: ${INFRAHUB_GIT_DELETE_GIT_BRANCH_AFTER_MERGE:-false}
   INFRAHUB_GIT_GLOBAL_CONFIG_FILE: ${INFRAHUB_GIT_GLOBAL_CONFIG_FILE:-/opt/infrahub/.gitconfig}
   INFRAHUB_GIT_IMPORT_SYNC_BRANCH_NAMES:
   INFRAHUB_GIT_REPOSITORIES_DIRECTORY: ${INFRAHUB_GIT_REPOSITORIES_DIRECTORY:-repositories}
@@ -89,6 +93,9 @@ x-infrahub-config: &infrahub_config
   INFRAHUB_LOGGING_REMOTE_ENABLE: ${INFRAHUB_LOGGING_REMOTE_ENABLE:-false}
   INFRAHUB_LOGGING_REMOTE_FRONTEND_DSN:
   INFRAHUB_LOGGING_REMOTE_GIT_AGENT_DSN:
+  INFRAHUB_LOG_FORWARDING_DESTINATIONS:
+  INFRAHUB_LOG_FORWARDING_DESTINATION_NAMES:
+  INFRAHUB_LOG_FORWARDING_HOSTNAME:
   INFRAHUB_LOG_LEVEL:
   INFRAHUB_MISC_MAXIMUM_VALIDATOR_EXECUTION_TIME: ${INFRAHUB_MISC_MAXIMUM_VALIDATOR_EXECUTION_TIME:-1800}
   INFRAHUB_MISC_PRINT_QUERY_DETAILS: ${INFRAHUB_MISC_PRINT_QUERY_DETAILS:-false}
@@ -110,6 +117,7 @@ x-infrahub-config: &infrahub_config
   INFRAHUB_STORAGE_DRIVER: ${INFRAHUB_STORAGE_DRIVER:-local}
   INFRAHUB_STORAGE_ENDPOINT_URL:
   INFRAHUB_STORAGE_LOCAL_PATH: ${INFRAHUB_STORAGE_LOCAL_PATH:-/opt/infrahub/storage}
+  INFRAHUB_STORAGE_MAX_FILE_SIZE: ${INFRAHUB_STORAGE_MAX_FILE_SIZE:-50}
   INFRAHUB_STORAGE_QUERYSTRING_AUTH: ${INFRAHUB_STORAGE_QUERYSTRING_AUTH:-false}
   INFRAHUB_STORAGE_USE_SSL: ${INFRAHUB_STORAGE_USE_SSL:-true}
   INFRAHUB_TELEMETRY_ENDPOINT: ${INFRAHUB_TELEMETRY_ENDPOINT:-https://telemetry.opsmill.cloud/infrahub}
@@ -124,7 +132,6 @@ x-infrahub-config: &infrahub_config
   INFRAHUB_WORKFLOW_ADDRESS: ${INFRAHUB_WORKFLOW_ADDRESS:-localhost}
   INFRAHUB_WORKFLOW_DEFAULT_WORKER_TYPE: ${INFRAHUB_WORKFLOW_DEFAULT_WORKER_TYPE:-infrahubasync}
   INFRAHUB_WORKFLOW_DRIVER: ${INFRAHUB_WORKFLOW_DRIVER:-worker}
-  INFRAHUB_WORKFLOW_ENABLE: ${INFRAHUB_WORKFLOW_ENABLE:-true}
   INFRAHUB_WORKFLOW_EXTRA_LOGGERS:
   INFRAHUB_WORKFLOW_EXTRA_LOG_LEVEL: ${INFRAHUB_WORKFLOW_EXTRA_LOG_LEVEL:-INFO}
   INFRAHUB_WORKFLOW_FLOW_RUN_COUNT_CACHE_THRESHOLD: ${INFRAHUB_WORKFLOW_FLOW_RUN_COUNT_CACHE_THRESHOLD:-100000}
@@ -162,7 +169,7 @@ x-task-manager-config:
 
 services:
   message-queue:
-    image: ${MESSAGE_QUEUE_DOCKER_IMAGE:-rabbitmq:3.13.7-management}
+    image: ${MESSAGE_QUEUE_DOCKER_IMAGE:-rabbitmq:4.2.1-management}
     restart: unless-stopped
     environment:
       RABBITMQ_DEFAULT_USER: *broker_username
@@ -177,7 +184,7 @@ services:
       - 15692:15692
 
   cache:
-    image: ${CACHE_DOCKER_IMAGE:-redis:7.2.11}
+    image: ${CACHE_DOCKER_IMAGE:-redis:8.4.0}
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
@@ -186,7 +193,7 @@ services:
       retries: 3
 
   database:
-    image: ${NEO4J_DOCKER_IMAGE:-neo4j:2025.03.0-community}
+    image: ${NEO4J_DOCKER_IMAGE:-neo4j:2025.10.1-community}
     restart: unless-stopped
     environment:
       NEO4J_AUTH: ${INFRAHUB_DB_USERNAME:-neo4j}/${INFRAHUB_DB_PASSWORD:-admin}
@@ -206,7 +213,7 @@ services:
       - 6362:6362
 
   task-manager:
-    image: "${INFRAHUB_DOCKER_IMAGE:-registry.opsmill.io/opsmill/infrahub}:${VERSION:-1.8.2}"
+    image: "${INFRAHUB_DOCKER_IMAGE:-registry.opsmill.io/opsmill/infrahub}:${VERSION:-1.9.6}"
     command: uvicorn --host 0.0.0.0 --port 4200 --factory infrahub.prefect_server.app:create_infrahub_prefect
     restart: unless-stopped
     depends_on:
@@ -222,14 +229,14 @@ services:
       start_period: 10s
 
   task-manager-db:
-    image: "${POSTGRES_DOCKER_IMAGE:-postgres:16-alpine}"
+    image: "${POSTGRES_DOCKER_IMAGE:-postgres:18-alpine}"
     restart: unless-stopped
     environment:
       - POSTGRES_USER=${INFRAHUB_TASKMANAGER_DB_USER:-postgres}
       - POSTGRES_PASSWORD=${INFRAHUB_TASKMANAGER_DB_PASSWORD:-postgres}
       - POSTGRES_DB=${INFRAHUB_TASKMANAGER_DB_DATABASE:-prefect}
     volumes:
-      - workflow_db:/var/lib/postgresql/data
+      - workflow_db:/var/lib/postgresql/18/docker
     healthcheck:
       test:
         - "CMD-SHELL"
@@ -239,7 +246,7 @@ services:
       retries: 5
 
   infrahub-server:
-    image: "${INFRAHUB_DOCKER_IMAGE:-registry.opsmill.io/opsmill/infrahub}:${VERSION:-1.8.2}"
+    image: "${INFRAHUB_DOCKER_IMAGE:-registry.opsmill.io/opsmill/infrahub}:${VERSION:-1.9.6}"
     restart: unless-stopped
     command: >
       gunicorn --config backend/infrahub/serve/gunicorn_config.py
@@ -285,7 +292,7 @@ services:
     deploy:
       mode: replicated
       replicas: 2
-    image: "${INFRAHUB_DOCKER_IMAGE:-registry.opsmill.io/opsmill/infrahub}:${VERSION:-1.8.2}"
+    image: "${INFRAHUB_DOCKER_IMAGE:-registry.opsmill.io/opsmill/infrahub}:${VERSION:-1.9.6}"
     command: prefect worker start --type infrahubasync --pool infrahub-worker --with-healthcheck
     restart: unless-stopped
     depends_on:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
     "types-pyyaml>=6.0.12",
     "types-requests>=2.32.0",
     "yamllint>=1.37.1",
-    "infrahub-testcontainers>=1.8.2",
+    "infrahub-testcontainers>=1.9.6",
     "rumdl>=0.1.71",
 ]
 

--- a/tasks.py
+++ b/tasks.py
@@ -10,7 +10,7 @@ CURRENT_DIRECTORY = Path(__file__).resolve()
 DOCUMENTATION_DIRECTORY = CURRENT_DIRECTORY.parent / "docs"
 MAIN_DIRECTORY_PATH = Path(__file__).parent
 
-infrahub_address = os.getenv("INFRAHUB_ADDRESS")
+infrahub_address = os.getenv("INFRAHUB_ADDRESS", "http://localhost:8000")
 base_compose_cmd: str = "docker compose"
 
 SEMAPHORE_URL = "http://localhost:3000"
@@ -283,9 +283,34 @@ def init_semaphore(
     print("=== Semaphore init complete ===")
 
 
+def wait_for_infrahub(url: str = infrahub_address) -> None:
+    """Block until the Infrahub server can serve its schema, with exponential backoff.
+
+    The server reports ``Started`` to Docker before it can answer schema queries, so a
+    fresh ``invoke init`` may hit it too early. Polling ``/api/schema`` here guarantees the
+    subsequent ``infrahubctl object load`` calls have a server ready on the same read path.
+    """
+    delay = 2
+    with httpx.Client(base_url=url, timeout=10) as client:
+        for attempt in range(1, 9):
+            try:
+                resp = client.get("/api/schema?branch=main")
+                if resp.status_code == httpx.codes.OK:
+                    print("Infrahub is reachable.")
+                    return
+                print(f"Waiting for Infrahub (attempt {attempt}/8, status={resp.status_code}, retry in {delay}s)...")
+            except httpx.HTTPError:
+                print(f"Waiting for Infrahub (attempt {attempt}/8, retry in {delay}s)...")
+            time.sleep(delay)
+            delay = min(delay * 2, 60)
+    print("ERROR: Infrahub not reachable after 8 attempts.")
+    sys.exit(1)
+
+
 @task(name="init", pre=[init_semaphore])
 def init(context: Context) -> None:
     """Initialize the demo: seed Semaphore, then load the repository and permissions into Infrahub."""
+    wait_for_infrahub()
     exec_cmd = ["uv run infrahubctl object load repository.yaml", "uv run infrahubctl object load permissions.yml"]
     with context.cd(MAIN_DIRECTORY_PATH):
         for cmd in exec_cmd:

--- a/uv.lock
+++ b/uv.lock
@@ -593,10 +593,10 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "infrahub-testcontainers", specifier = ">=1.8.2" },
+    { name = "infrahub-testcontainers", specifier = ">=1.9.6" },
     { name = "mypy", specifier = ">=1.20.1" },
     { name = "pytest", specifier = ">=8.0.0,<10" },
-    { name = "pytest-asyncio", specifier = ">=0.23.0,<1" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0,<2" },
     { name = "pytest-clarity", specifier = ">=1.0.1" },
     { name = "pytest-httpx", specifier = ">=0.30.0,<0.37" },
     { name = "ruff", specifier = ">=0.14.4" },
@@ -642,7 +642,7 @@ all = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.8.2"
+version = "1.9.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -652,9 +652,9 @@ dependencies = [
     { name = "pytest" },
     { name = "testcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/bf/f221522c9f0ea4d63f123a8cb12d011b4a2d9a59330277d320e16c4aa3a5/infrahub_testcontainers-1.8.2.tar.gz", hash = "sha256:30100d57c3da404e754b8637a68405f42e36d50782277fa802c17471d73820e4", size = 17334, upload-time = "2026-03-25T14:49:05.921Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/25/0e56af611410a79ab242dea99a1892af8840524c58870b3050e59a4f99b1/infrahub_testcontainers-1.9.6.tar.gz", hash = "sha256:c75015a166d05aaa00804bf5be42f041e10745a7fa4c6ac13713febc60ae617f", size = 17365, upload-time = "2026-05-20T19:42:41.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/66/f5148659cec74c8bee6c8f0b36cee55686ce012fbc4c52010491e0eca350/infrahub_testcontainers-1.8.2-py3-none-any.whl", hash = "sha256:e11fa65627c1b845858588d2f20089beb60185f7c24a67347943273f65da7171", size = 23182, upload-time = "2026-03-25T14:49:04.66Z" },
+    { url = "https://files.pythonhosted.org/packages/18/25/284135f880d60d1c912a269c88a048a420a691b5b337d05027d269803d48/infrahub_testcontainers-1.9.6-py3-none-any.whl", hash = "sha256:6a2d185513b56071e0235ec71d8ac33be1e29dc2c6815b1ec5ce1d9994cc4e74", size = 23197, upload-time = "2026-05-20T19:42:40.398Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Pulls upstream Infrahub 1.9.6 docker-compose verbatim and bumps the demo-specific image tag plus the infrahub-testcontainers dev dependency to match. Includes major-version image bumps from upstream (Postgres 16→18, Neo4j 2025.10, Redis 8, RabbitMQ 4), new env vars exposed in 1.9 (DB retry tuning, branch-after-merge lifecycle, log forwarding, storage file-size cap), and removal of the always-on broker/cache/workflow enable flags.

Note: Postgres major bump requires `invoke destroy` (volume layout changed to /var/lib/postgresql/18/docker, matching the postgres:18-alpine image's default PGDATA).