### PR TITLE
WIP: fix(permissions, schema): restrict operator merges, grant operator PC permissions, nest CircuitContract menu

### DIFF
--- a/bootstrap/permissions.yml
+++ b/bootstrap/permissions.yml
@@ -45,10 +45,10 @@ spec:
             action: "manage_repositories"
           # - decision: 6
           #   action: "manage_schema"
-          - decision: 6
-            action: "merge_branch"
-          - decision: 6
-            action: "merge_proposed_change"
+          # - decision: 6
+          #   action: "merge_branch"
+          # - decision: 6
+          #   action: "merge_proposed_change"
           - decision: 6
             action: "review_proposed_change"
 ---

--- a/bootstrap/permissions.yml
+++ b/bootstrap/permissions.yml
@@ -31,6 +31,18 @@ spec:
             name: "ProposedChange"
             action: "any"
             decision: 6
+          - namespace: "Core"
+            name: "ChangeComment"
+            action: "any"
+            decision: 6
+          - namespace: "Core"
+            name: "ChangeThread"
+            action: "any"
+            decision: 6
+          - namespace: "Core"
+            name: "ThreadComment"
+            action: "any"
+            decision: 6
     - name: "operator-role-global"
       permissions:
         kind: CoreGlobalPermission

--- a/schemas/circuit/circuit.yml
+++ b/schemas/circuit/circuit.yml
@@ -148,6 +148,7 @@ nodes:
     description: Contract file associated with a circuit.
     label: Circuit Contract
     icon: mdi:file-document
+    menu_placement: DcimCircuit
     attributes:
       - name: contract_start_date
         kind: DateTime


### PR DESCRIPTION
> **Blocked / WIP.** This PR cannot land until the upstream Infrahub fix on branch [`ic-fix-proposed-change-permissions`](https://github.com/opsmill/infrahub/tree/ic-fix-proposed-change-permissions) (tracking [opsmill/infrahub#8755](https://github.com/opsmill/infrahub/issues/8755)) is merged and released. Without it, the new `Core/ChangeComment`, `Core/ChangeThread`, and `Core/ThreadComment` permissions on the operator role have no effect — the `DefaultBranchPermissionChecker` still blocks those mutations behind the global `edit_default_branch` permission, which the operator role does not have.

## Summary
- Comment out `merge_branch` and `merge_proposed_change` for the operator group so operators can review but no longer self-merge proposed changes.
- Add `Core/ChangeComment`, `Core/ChangeThread`, and `Core/ThreadComment` object permissions (`any`, `ALLOW_ALL`) to `operator-role-object`. `Core/ProposedChange/any/ALLOW_ALL` was already in place; these three close the gap for commenting, threads, and thread replies once the upstream auth-chain fix lands.
- Add `menu_placement: DcimCircuit` to `DcimCircuitContract` so the contract appears nested under its circuit in the Infrahub menu.

## Why ALLOW_ALL and not ALLOW_DEFAULT
Object-permission specificity wins over the wildcard `*/*/any/ALLOW_OTHER` that already grants operators non-default-branch access. Writing `ALLOW_DEFAULT` (specificity 3) would beat `ALLOW_OTHER` (specificity 1) and *strip* operators' access to PCs on non-default branches. `ALLOW_ALL` covers both halves and stays above the wildcard without shadowing it.

## Test plan
- [ ] Upstream Infrahub PR merged and a release containing the auth-chain fix is available.
- [ ] Rebuild the demo image against that release.
- [ ] Reload permissions; confirm `john` can: create a PC, comment, open a thread, reply on a thread, approve, close, and reopen.
- [ ] Confirm `john` still **cannot** merge a PC (`CoreProposedChangeMerge` and the `merge_proposed_change` / `merge_branch` globals remain denied).
- [ ] Reload the schema; confirm `DcimCircuitContract` appears nested under `DcimCircuit` in the menu rather than at the top level.
- [ ] `uv run invoke format lint` passes.
- [ ] `uv run infrahubctl schema check schemas/` passes.