### PR TITLE
fix(generator): avoid upsert on pool-sourced VLAN HFID

### DIFF
--- a/generators/implement_dedicated_internet.py
+++ b/generators/implement_dedicated_internet.py
@@ -77,6 +77,20 @@ class DedicatedInternetGenerator(InfrahubGenerator):
         """Create a VLAN with ID coming from the pool provided and assign this VLAN to the service."""
         self.log.info("Allocating VLAN to this service...")
 
+        # Identity here is "one VLAN per service", not the VLAN's human-friendly identifier.
+        # `vlan_id` is allocated from a CoreNumberPool and is part of the HFID, so it has no
+        # concrete value until creation; `allow_upsert=True` therefore cannot resolve the HFID
+        # (infrahub-sdk >= 1.10 raises a ValidationError). Reuse the existing VLAN on re-runs and
+        # create with a plain save otherwise. See opsmill/infrahub-sdk-python#339 and #396.
+        existing_vlans = await self.client.filters(
+            kind=IpamVLAN,
+            service__ids=[self.customer_service.id],
+        )
+        if existing_vlans:
+            self.allocated_vlan = existing_vlans[0]
+            self.log.info(f"VLAN `{self.allocated_vlan.name.value}` already allocated to this service; reusing.")
+            return
+
         # Get resource pool
         resource_pool = await self.client.get(
             kind=CoreNumberPool,
@@ -96,8 +110,9 @@ class DedicatedInternetGenerator(InfrahubGenerator):
             location=[self.customer_service.location.id],
         )
 
-        # And save it to Infrahub
-        await self.allocated_vlan.save(allow_upsert=True)
+        # Plain create (not an upsert): the pool allocates a concrete vlan_id at creation time, and
+        # idempotency on re-runs is handled by the lookup above.
+        await self.allocated_vlan.save()
 
         self.log.info(f"VLAN `{self.allocated_vlan.name.value}` assigned!")
 


### PR DESCRIPTION
## Problem

Upgrading the demo to Infrahub 1.10 broke the dedicated internet generator on the **first run**:

```
Failed to execute generator: vlan_id: Attribute 'vlan_id' is sourced from a CoreNumberPool
and is part of this node's human-friendly identifier. Upsert cannot resolve the HFID without
a concrete value. Use an explicit id, or create the node first and update it in a separate call.
```

## Root cause

infrahub-sdk >= 1.10 added a client-side guard (`_validate_upsert`, opsmill/infrahub-sdk-python#1014) that rejects `save(allow_upsert=True)` when an HFID attribute is sourced from a `CoreNumberPool`. `IpamVLAN`'s HFID is `[l2domain, vlan_id]`, and `vlan_id` is allocated from a number pool — its value doesn't exist until the server creates the node, so the SDK can't resolve the HFID to do the "find" half of the upsert.

`allocate_vlan()` was creating the VLAN with `vlan_id=resource_pool` and then calling `save(allow_upsert=True)` on the brand-new (id-less) node — exactly the path the guard blocks. This wasn't an error before because the older SDK didn't have the check (it previously failed in a more cryptic way; see opsmill/infrahub-sdk-python#339).

## Fix

The VLAN's identity in this generator is really *"one VLAN per service"*, not its HFID (whose `vlan_id` is an output of allocation, not an input key). So:

- Look up an existing VLAN via the `service` relationship and reuse it on re-runs (idempotency).
- Otherwise create with a plain `save()` so the pool allocates `vlan_id` server-side.

There is no SDK-native idempotent number-pool allocation today; opsmill/infrahub-sdk-python#396 (identifier support for number pools) would let us go back to `allow_upsert=True` with a concrete `vlan_id`.

## Verification

Ran against a live Infrahub 1.10 instance via `infrahubctl generator dedicated_internet_generator service_identifier=<svc>`:

- **Run 1 (fresh service):** VLAN + prefix + port + gateway all allocated, no error.
- **Runs 2 & 3 (re-run):** "already allocated to this service; reusing" branch hit — no duplicate, no error.
- VLAN count for the service stays **exactly 1** across runs.
- `ruff check` on the file passes.

Refs opsmill/infrahub-sdk-python#339, opsmill/infrahub-sdk-python#396

🤖 Generated with [Claude Code](https://claude.com/claude-code)